### PR TITLE
[release-3.12] Manual cherry-pick: Set TLS minimum version to 1.2

### DIFF
--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -155,7 +155,7 @@ controllerManager:
   livenessTimeout: 1
   priorityClassName: system-cluster-critical
   disableCertRotation: false
-  tlsMinVersion: 1.3
+  tlsMinVersion: 1.2
   clientCertName: ""
   affinity:
     podAntiAffinity:

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -155,7 +155,7 @@ controllerManager:
   livenessTimeout: 1
   priorityClassName: system-cluster-critical
   disableCertRotation: false
-  tlsMinVersion: 1.3
+  tlsMinVersion: 1.2
   clientCertName: ""
   affinity:
     podAntiAffinity:

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -155,7 +155,7 @@ controllerManager:
   livenessTimeout: 1
   priorityClassName: system-cluster-critical
   disableCertRotation: false
-  tlsMinVersion: 1.3
+  tlsMinVersion: 1.2
   clientCertName: ""
   affinity:
     podAntiAffinity:

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -53,7 +53,7 @@ var (
 	logDenies                          = flag.Bool("log-denies", false, "log detailed info on each deny")
 	emitAdmissionEvents                = flag.Bool("emit-admission-events", false, "(alpha) emit Kubernetes events for each admission violation")
 	admissionEventsInvolvedNamespace   = flag.Bool("admission-events-involved-namespace", false, "emit admission events for each violation in the involved objects namespace, the default (false) generates events in the namespace Gatekeeper is installed in. Admission events from cluster-scoped resources will still follow the default behavior")
-	tlsMinVersion                      = flag.String("tls-min-version", "1.3", "minimum version of TLS supported")
+	tlsMinVersion                      = flag.String("tls-min-version", "1.2", "minimum version of TLS supported")
 	serviceaccount                     = fmt.Sprintf("system:serviceaccount:%s:%s", util.GetNamespace(), serviceAccountName)
 	clientCAName                       = flag.String("client-ca-name", "", "name of the certificate authority bundle to authenticate the Kubernetes API server requests against")
 	certCNName                         = flag.String("client-cn-name", "kube-apiserver", "expected CN name on the client certificate attached by apiserver in requests to the webhook")

--- a/pkg/webhook/common_test.go
+++ b/pkg/webhook/common_test.go
@@ -33,7 +33,7 @@ func (w chanWriter) Write(p []byte) (n int, err error) {
 
 func TestCongifureWebhookServer(t *testing.T) {
 	expectedServer := &webhook.Server{
-		TLSMinVersion: "1.3",
+		TLSMinVersion: "1.2",
 	}
 
 	if *clientCAName != "" {


### PR DESCRIPTION
Manual cherry-pick of:
- #176 

ref: https://issues.redhat.com/browse/ACM-6233

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>
(cherry picked from commit fe16f20d75a0dc605ab2ab7947b95426ac6851bd)
