### PR TITLE
Change the Dockerfile and Github workflow to support multiple platform builds

### DIFF
--- a/.github/workflows/build-push-stolostron.yaml
+++ b/.github/workflows/build-push-stolostron.yaml
@@ -23,12 +23,10 @@ jobs:
         username: ${{ secrets.QUAY_USER }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: build
+    - name: build and push
       run: |
-        REPOSITORY=${{env.REPOSITORY}} VERSION=${{env.VERSION_TAG}} \
-        PLATFORM="linux/amd64,linux/arm64,linux/arm/v7"  OUTPUT_TYPE=type=registry GENERATE_ATTESTATIONS=true make docker-buildx-release
+        REPOSITORY=${{env.REPOSITORY}} \
+        PLATFORM="linux/amd64,linux/arm64,linux/arm/v8" \
+        OUTPUT_TYPE=type=registry GENERATE_ATTESTATIONS=true \
+        docker-buildx-release
 
-    - name: push
-      run: |
-        docker push ${{env.REPOSITORY}}:${{env.VERSION_TAG}}
-        


### PR DESCRIPTION
Change the Dockerfile and Github workflow to support multiple platform builds  (arm64/v8, arm64, amd64) for the dev environment.