### PR TITLE
Restrict Konflux image builds

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dockerfile": {
+    "ignorePaths": [
+      "crd.Dockerfile",
+      "build/tooling/Dockerfile"
+    ]
+  },
+  "packageRules": [
+    {
+      "matchManagers": "helm-values",
+      "enabled": false
+    }
+  ],
   "schedule": "before 8am on Monday",
   "timezone": "America/New_York"
 }

--- a/.tekton/gatekeeper-3-17-pull-request.yaml
+++ b/.tekton/gatekeeper-3-17-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-3.17" && (".tekton/gatekeeper-*.yaml".pathChanged() || "Dockerfile".pathChanged() ||  "build/Dockerfile.rhtap".pathChanged() || "go.(mod|sum)".pathChanged() ||  "main.go".pathChanged() || "(apis|pkg|vendor)/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17

--- a/.tekton/gatekeeper-3-17-push.yaml
+++ b/.tekton/gatekeeper-3-17-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     build.appstudio.openshift.io/build-nudge-files: "build/konflux-patch.sh"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-3.17" && (".tekton/gatekeeper-*.yaml".pathChanged() || "Dockerfile".pathChanged() ||  "build/Dockerfile.rhtap".pathChanged() || "go.(mod|sum)".pathChanged() ||  "main.go".pathChanged() || "(apis|pkg|vendor)/***".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: gatekeeper-operator-3-17

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,19 @@ RUN if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
     fi
 
 WORKDIR /go/src/github.com/open-policy-agent/gatekeeper
-COPY . .
 
+# Copy the Go module manifests and dependencies
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Copy the source code
+COPY main.go main.go
+COPY apis/ apis/
+COPY pkg/ pkg/
+
+
+# Build the controller
 RUN  if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
         export CC=aarch64-linux-gnu-gcc; \
     elif [ "${TARGETPLATFORM}" = "linux/arm/v8" ]; then \

--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -4,10 +4,22 @@ ENV LDFLAGS="-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=v
     CGO_ENABLED=1
 
 WORKDIR /go/src/github.com/open-policy-agent/gatekeeper
-COPY . .
 
+# Copy the Go module manifests and dependencies
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+
+# Copy the source code
+COPY main.go main.go
+COPY apis/ apis/
+COPY pkg/ pkg/
+
+# Build the controller
 RUN go build -mod vendor -a -ldflags "${LDFLAGS}" -o manager
 
+
+# Copy the binary to the UBI-minimal base image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/manager .


### PR DESCRIPTION
Reconfigures the Dockerfile to only copy required files during build. Following from this, Konflux will only build an image for the containerfile and the containerfile's dependencies. Probably not required since we really only build when there's a new release, but it could be useful if, for example, CI or tests are updated here to unblock the operator build that doesn't require a new image.

Also attempts to reconfigure MintMaker/Renovate to silence irrelevant MintMaker updates.
