### PR TITLE
[release-3.15] Revert `controller-gen` bump

### DIFF
--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23-bullseye@sha256:b7575efc7b1ca22e9ce7510979d4c1b5564c970279a66aea44e8b57ed133bfc7
 
-RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5
+RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
 RUN GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen@v0.25.4
 
 RUN mkdir /gatekeeper

--- a/config/crd/bases/_.yaml
+++ b/config/crd/bases/_.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
 spec:
   group: ""
   names:

--- a/config/crd/bases/config.gatekeeper.sh_configs.yaml
+++ b/config/crd/bases/config.gatekeeper.sh_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: configs.config.gatekeeper.sh
 spec:
   group: config.gatekeeper.sh

--- a/config/crd/bases/expansion.gatekeeper.sh_expansiontemplate.yaml
+++ b/config/crd/bases/expansion.gatekeeper.sh_expansiontemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: expansiontemplate.expansion.gatekeeper.sh
 spec:
   group: expansion.gatekeeper.sh

--- a/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
+++ b/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: matchcrd.match.gatekeeper.sh
 spec:
   group: match.gatekeeper.sh

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: assign.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
@@ -284,8 +284,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified
@@ -311,6 +309,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -648,8 +647,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified
@@ -675,6 +672,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -1012,8 +1010,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified
@@ -1039,6 +1035,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: assignimage.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
@@ -272,6 +272,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: assignmetadata.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
@@ -254,8 +254,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified
@@ -566,8 +564,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified
@@ -878,8 +874,6 @@ spec:
                             description: Provider is the name of the external data
                               provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified

--- a/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: modifyset.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
@@ -271,6 +271,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -601,6 +602,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -929,6 +931,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: constraintpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_expansiontemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_expansiontemplatepodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: expansiontemplatepodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_mutatorpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_mutatorpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: mutatorpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/syncset.gatekeeper.sh_syncsets.yaml
+++ b/config/crd/bases/syncset.gatekeeper.sh_syncsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: syncsets.syncset.gatekeeper.sh
 spec:
   group: syncset.gatekeeper.sh

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -65,9 +65,18 @@ rules:
   - update
 - apiGroups:
   - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - expansion.gatekeeper.sh
-  - mutations.gatekeeper.sh
-  - status.gatekeeper.sh
   resources:
   - '*'
   verbs:
@@ -91,6 +100,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - mutations.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy
   resourceNames:
   - gatekeeper-admin
@@ -98,6 +119,18 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+- apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - templates.gatekeeper.sh
   resources:

--- a/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assign.mutations.gatekeeper.sh
@@ -283,8 +283,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -306,6 +304,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -633,8 +632,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -656,6 +653,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -983,8 +981,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -1006,6 +1002,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignimage.mutations.gatekeeper.sh
@@ -272,6 +272,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh
@@ -254,8 +254,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -554,8 +552,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -854,8 +850,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.

--- a/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplate.expansion.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplatepodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: modifyset.mutations.gatekeeper.sh
@@ -271,6 +271,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -591,6 +592,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -909,6 +911,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate

--- a/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: mutatorpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: syncsets.syncset.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -71,9 +71,18 @@ rules:
   - update
 - apiGroups:
   - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - expansion.gatekeeper.sh
-  - mutations.gatekeeper.sh
-  - status.gatekeeper.sh
   resources:
   - '*'
   verbs:
@@ -96,6 +105,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - mutations.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- if and .Values.psp.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:
   - policy
@@ -106,6 +127,18 @@ rules:
   verbs:
   - use
 {{- end }}
+- apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - templates.gatekeeper.sh
   resources:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -34,7 +34,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assign.mutations.gatekeeper.sh
@@ -315,8 +315,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -338,6 +336,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -665,8 +664,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -688,6 +685,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -1015,8 +1013,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -1038,6 +1034,7 @@ spec:
                         not applied. All `subPath` entries must be a prefix of `location`. Any
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
+
 
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
@@ -1107,7 +1104,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignimage.mutations.gatekeeper.sh
@@ -1378,6 +1375,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -1446,7 +1444,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh
@@ -1698,8 +1696,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -1998,8 +1994,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -2298,8 +2292,6 @@ spec:
                           provider:
                             description: Provider is the name of the external data provider.
                             type: string
-                        required:
-                        - provider
                         type: object
                       fromMetadata:
                         description: FromMetadata assigns a value from the specified metadata field.
@@ -2369,7 +2361,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh
@@ -2487,7 +2479,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh
@@ -2567,7 +2559,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
@@ -3004,7 +2996,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplate.expansion.gatekeeper.sh
@@ -3257,7 +3249,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplatepodstatuses.status.gatekeeper.sh
@@ -3332,7 +3324,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: modifyset.mutations.gatekeeper.sh
@@ -3602,6 +3594,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -3921,6 +3914,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -4240,6 +4234,7 @@ spec:
                         glob characters will take on the same value as was used to
                         expand the matching glob in `location`.
 
+
                         Available Tests:
                         * MustExist    - the path must exist or do not mutate
                         * MustNotExist - the path must not exist or do not mutate.
@@ -4312,7 +4307,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: mutatorpodstatuses.status.gatekeeper.sh
@@ -4471,7 +4466,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   labels:
     gatekeeper.sh/system: "yes"
   name: syncsets.syncset.gatekeeper.sh
@@ -4633,9 +4628,18 @@ rules:
   - update
 - apiGroups:
   - constraints.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - expansion.gatekeeper.sh
-  - mutations.gatekeeper.sh
-  - status.gatekeeper.sh
   resources:
   - '*'
   verbs:
@@ -4659,6 +4663,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - mutations.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy
   resourceNames:
   - gatekeeper-admin
@@ -4666,6 +4682,18 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+- apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - templates.gatekeeper.sh
   resources:

--- a/pkg/target/matchcrd_constant.go
+++ b/pkg/target/matchcrd_constant.go
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: matchcrd.match.gatekeeper.sh
 spec:
   group: match.gatekeeper.sh


### PR DESCRIPTION
Upstream we rely on the RBAC rules being separate so they can be removed. I don't feel comfortable fiddling with that logic in a z-stream.

Followup to:
- #294 