### PR TITLE
Disable `dockerfile` updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["schedule:earlyMondays"],
   "dockerfile": {
-    "ignorePaths": ["crd.Dockerfile", "build/tooling/Dockerfile"]
+    "enabled": false
   },
   "helm-values": {
     "enabled": false
@@ -10,7 +10,7 @@
   "gomod": {
     "groupName": "gomod"
   },
-  "packageRules":[
+  "packageRules": [
     {
       "groupName": "gomod vulnerability",
       "matchBaseBranches": ["/^release-[0-9]+\\.[0-9+]$/"],


### PR DESCRIPTION
Since we're syncing with upstream and use tags for Konflux, these updates are more noisy than anything.