### PR TITLE
Enable MintMaker updates for the Golang builder

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,9 +20,9 @@
       "enabled": false
     },
     {
+      "groupName": "Containerfile image update",
       "matchBaseBranches": ["/^release-[0-9]+\\.[0-9]+$/"],
       "matchManagers": ["dockerfile"],
-      "matchPackageNames": ["/registry\\.access\\.redhat\\.com\\/ubi[0-9]+\\/ubi-minimal/"],
       "managerFilePatterns": ["build/Dockerfile.rhtap"],
       "ignorePaths": ["*"],
       "enabled": true,


### PR DESCRIPTION
Base image updates were enabled, but we'll want rebuilds when Golang gets updates also. I isolated this to the base image initially because it's public, but hopefully MintMaker would also have access to credentialed Red Hat registries also by default.

Followup to:
- #558 